### PR TITLE
Linkfix for online version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Adventure: Revisited
 TypeScript implementation of Atari's "Adventure" game for the 2600 for web
 
-**Play it online here: [http://peterhirschberg.com/adventure/play/](http://peterhirschberg.com/adventure/play/)**
+**Play it online here: [https://peterhirschberg.com/#/AdventurePlay](https://peterhirschberg.com/#/AdventurePlay)**
 
 ## Build instructions
 ```


### PR DESCRIPTION
Updates link to play Adventure online from http://peterhirschberg.com/adventure/play/ (404) to https://peterhirschberg.com/#/AdventurePlay (200).